### PR TITLE
feat: add Menus module with R operations and Swagger documentation

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,7 @@
     "@nestjs/swagger": "^11.2.0",
     "@prisma/client": "6.14.0",
     "bcryptjs": "^3.0.2",
+    "builder-pattern": "^2.2.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
     "dotenv": "^17.2.1",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
     "@eslint/js": "^9.18.0",
+    "@faker-js/faker": "^9.9.0",
     "@nestjs/cli": "^11.0.0",
     "@nestjs/schematics": "^11.0.0",
     "@nestjs/testing": "^11.0.1",
@@ -54,6 +56,7 @@
     "eslint-plugin-prettier": "^5.2.2",
     "globals": "^16.0.0",
     "jest": "^29.7.0",
+    "jest-mock-extended": "^4.0.0",
     "prettier": "^3.4.2",
     "prisma": "^6.14.0",
     "source-map-support": "^0.5.21",

--- a/server/pnpm-lock.yaml
+++ b/server/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       bcryptjs:
         specifier: ^3.0.2
         version: 3.0.2
+      builder-pattern:
+        specifier: ^2.2.0
+        version: 2.2.0
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -60,6 +63,9 @@ importers:
       '@eslint/js':
         specifier: ^9.18.0
         version: 9.33.0
+      '@faker-js/faker':
+        specifier: ^9.9.0
+        version: 9.9.0
       '@nestjs/cli':
         specifier: ^11.0.0
         version: 11.0.10(@swc/cli@0.6.0(@swc/core@1.13.3)(chokidar@4.0.3))(@swc/core@1.13.3)(@types/node@22.17.2)
@@ -102,6 +108,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@22.17.2)(typescript@5.9.2))
+      jest-mock-extended:
+        specifier: ^4.0.0
+        version: 4.0.0(@jest/globals@29.7.0)(jest@29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@22.17.2)(typescript@5.9.2)))(typescript@5.9.2)
       prettier:
         specifier: ^3.4.2
         version: 3.6.2
@@ -370,6 +379,10 @@ packages:
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@faker-js/faker@9.9.0':
+    resolution: {integrity: sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==}
+    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1517,6 +1530,9 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  builder-pattern@2.2.0:
+    resolution: {integrity: sha512-cES3qdeBzA4QyJi7rV/l/kAhIFX6AKo3vK66ZPXLNpjcQWCS8sjLKscly8imlfW2YPTo/hquMRMnaWpZ80Kj+g==}
+
   busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
@@ -2443,6 +2459,13 @@ packages:
     resolution: {integrity: sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  jest-mock-extended@4.0.0:
+    resolution: {integrity: sha512-7BZpfuvLam+/HC+NxifIi9b+5VXj/utUDMPUqrDJehGWVuXPtLS9Jqlob2mJLrI/pg2k1S8DMfKDvEB88QNjaQ==}
+    peerDependencies:
+      '@jest/globals': ^28.0.0 || ^29.0.0 || ^30.0.0
+      jest: ^24.0.0 || ^25.0.0 || ^26.0.0 || ^27.0.0 || ^28.0.0 || ^29.0.0 || ^30.0.0
+      typescript: ^3.0.0 || ^4.0.0 || ^5.0.0
+
   jest-mock@29.7.0:
     resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -3362,6 +3385,14 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  ts-essentials@10.1.1:
+    resolution: {integrity: sha512-4aTB7KLHKmUvkjNj8V+EdnmuVTiECzn3K+zIbRthumvHu+j44x3w63xpfs0JL3NGIzGXqoQ7AV591xHO+XrOTw==}
+    peerDependencies:
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ts-jest@29.4.1:
     resolution: {integrity: sha512-SaeUtjfpg9Uqu8IbeDKtdaS0g8lS6FT6OzM3ezrDfErPJPHNDo/Ey+VFGP1bQIDfagYDLyRpd7O15XpG1Es2Uw==}
     engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
@@ -3897,6 +3928,8 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.2
       levn: 0.4.1
+
+  '@faker-js/faker@9.9.0': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -5264,6 +5297,8 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  builder-pattern@2.2.0: {}
+
   busboy@1.6.0:
     dependencies:
       streamsearch: 1.1.0
@@ -6299,6 +6334,13 @@ snapshots:
       slash: 3.0.0
       stack-utils: 2.0.6
 
+  jest-mock-extended@4.0.0(@jest/globals@29.7.0)(jest@29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@22.17.2)(typescript@5.9.2)))(typescript@5.9.2):
+    dependencies:
+      '@jest/globals': 29.7.0
+      jest: 29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@22.17.2)(typescript@5.9.2))
+      ts-essentials: 10.1.1(typescript@5.9.2)
+      typescript: 5.9.2
+
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
@@ -7255,6 +7297,10 @@ snapshots:
 
   ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
+      typescript: 5.9.2
+
+  ts-essentials@10.1.1(typescript@5.9.2):
+    optionalDependencies:
       typescript: 5.9.2
 
   ts-jest@29.4.1(@babel/core@7.28.3)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.28.3))(jest-util@29.7.0)(jest@29.7.0(@types/node@22.17.2)(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@22.17.2)(typescript@5.9.2)))(typescript@5.9.2):

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -1,6 +1,5 @@
 generator client {
   provider = "prisma-client-js"
-  output   = "../generated/prisma"
 }
 
 datasource db {

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from '../generated/prisma';
+import { PrismaClient } from '@prisma/client';
 import * as bcrypt from 'bcryptjs';
 import {
   userData,

--- a/server/public/swagger/swagger-inject.js
+++ b/server/public/swagger/swagger-inject.js
@@ -17,7 +17,7 @@
 
   // Check access
   async function checkAccess() {
-    const input = prompt('🔒 Enter access code to view Swagger UI:', '');
+    const input = prompt('🔒 Enter access code to view Swagger UI:', 'apiv1');
     if (!input) {
       alert('❌ Access denied. Redirecting...');
       window.location.href = 'https://google.com';

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -11,6 +11,7 @@ import { AuthModule } from 'src/modules/auth/auth.module';
 import { APP_GUARD } from '@nestjs/core';
 import { AuthGuard } from 'src/modules/auth/guards/auth.guard';
 import { RoleGuard } from 'src/modules/auth/guards/role.guard';
+import { MenusModule } from './modules/menus/menus.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { RoleGuard } from 'src/modules/auth/guards/role.guard';
     HealthModule,
     UsersModule,
     AuthModule,
+    MenusModule,
   ],
   providers: [
     {

--- a/server/src/modules/health/controller/health.controller.ts
+++ b/server/src/modules/health/controller/health.controller.ts
@@ -6,6 +6,7 @@ import {
   CheckHealthUseCase,
   CheckHealthUseCaseToken,
 } from 'src/modules/health/use-case/check-health.usecase';
+import { Public } from 'src/shared/decorators/public.decorator';
 import ValidateResponse from 'src/shared/decorators/validate-response.decorator';
 
 @ApiTags('Health')
@@ -17,6 +18,7 @@ export class HealthController {
   ) {}
 
   @Get()
+  @Public()
   @CheckHealthDocument()
   @ValidateResponse(CheckHealthDto)
   checkHealth(): CheckHealthDto {

--- a/server/src/modules/menus/controllers/menus.controller.ts
+++ b/server/src/modules/menus/controllers/menus.controller.ts
@@ -1,0 +1,38 @@
+import {
+  Controller,
+  Get,
+  Query,
+  Inject,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import {
+  GetAllMenuItemsUseCase,
+  GetAllMenuItemsUseCaseToken,
+} from 'src/modules/menus/usecases/get-all-menu-items.usecase';
+import { GetAllMenuDto } from 'src/modules/menus/dto/request/get-all-menu.dto';
+import ValidateResponse from 'src/shared/decorators/validate-response.decorator';
+import { GetAllMenuItemsResponse } from 'src/modules/menus/dto/response/get-all-menu-item.response';
+import { GetAllMenuItemsDocument } from 'src/modules/menus/doc/menu-item-document.swagger';
+import { Public } from 'src/shared/decorators/public.decorator';
+
+@Controller('menus')
+@ApiTags('menus')
+export class MenusController {
+  constructor(
+    @Inject(GetAllMenuItemsUseCaseToken)
+    private readonly getAllUseCase: GetAllMenuItemsUseCase,
+  ) {}
+
+  @Get()
+  @Public()
+  @HttpCode(HttpStatus.OK)
+  @GetAllMenuItemsDocument()
+  @ValidateResponse(GetAllMenuItemsResponse)
+  async getAll(
+    @Query() filter: GetAllMenuDto,
+  ): Promise<GetAllMenuItemsResponse> {
+    return this.getAllUseCase.execute(filter);
+  }
+}

--- a/server/src/modules/menus/doc/menu-item-document.swagger.ts
+++ b/server/src/modules/menus/doc/menu-item-document.swagger.ts
@@ -1,0 +1,55 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { GetAllMenuItemsResponse } from 'src/modules/menus/dto/response/get-all-menu-item.response';
+
+export function GetAllMenuItemsDocument() {
+  return applyDecorators(
+    ApiTags('menus'),
+    ApiBearerAuth(),
+    ApiOperation({
+      summary: 'Get menu items with pagination',
+      description:
+        'Retrieve a paginated list of menu items with optional filtering (active, category) and search. Authentication required.',
+    }),
+    ApiQuery({
+      name: 'page',
+      required: false,
+      type: Number,
+      description: 'Page number (default: 1)',
+      example: 1,
+    }),
+    ApiQuery({
+      name: 'search',
+      required: false,
+      type: String,
+      description: 'Search term for name or description',
+      example: 'latte',
+    }),
+    ApiQuery({
+      name: 'active',
+      required: false,
+      type: Boolean,
+      description: 'Filter by availability',
+      example: true,
+    }),
+    ApiResponse({
+      status: 200,
+      description: 'Successfully retrieved menu items',
+      type: GetAllMenuItemsResponse,
+    }),
+    ApiResponse({
+      status: 401,
+      description: 'Unauthorized - Invalid or missing token',
+    }),
+    ApiResponse({
+      status: 403,
+      description: 'Forbidden - Insufficient permissions',
+    }),
+  );
+}

--- a/server/src/modules/menus/dto/request/get-all-menu.dto.ts
+++ b/server/src/modules/menus/dto/request/get-all-menu.dto.ts
@@ -1,0 +1,61 @@
+import { Type } from 'class-transformer';
+import {
+  IsBoolean,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  Min,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class GetAllMenuDto {
+  @ApiPropertyOptional({
+    description: 'Filter by active status',
+    example: true,
+  })
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  active?: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Filter by category id (UUID)',
+    example: '550e8400-e29b-41d4-a716-446655440001',
+  })
+  @IsOptional()
+  @IsUUID()
+  categoryId?: string;
+
+  @ApiPropertyOptional({
+    description: 'Full text search on name/description',
+    example: 'latte',
+  })
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @ApiPropertyOptional({
+    description: 'Page number for pagination (1-based)',
+    example: 1,
+    default: 1,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @ApiPropertyOptional({
+    description: 'Page size for pagination',
+    example: 20,
+    default: 20,
+  })
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  pageSize?: number = 20;
+}

--- a/server/src/modules/menus/dto/response/get-all-menu-item.response.ts
+++ b/server/src/modules/menus/dto/response/get-all-menu-item.response.ts
@@ -1,0 +1,23 @@
+import { MenuEntity } from 'src/modules/menus/entities/menu-item.entity';
+import { PaginationMetaDto } from 'src/shared/dtos/pagination.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import { Type } from 'class-transformer';
+import { ValidateNested } from 'class-validator';
+
+export class GetAllMenuItemsResponse {
+  @ApiProperty({
+    description: 'List of menu items',
+    type: [MenuEntity],
+  })
+  @Type(() => MenuEntity)
+  @ValidateNested({ each: true })
+  data: MenuEntity[];
+
+  @ApiProperty({
+    description: 'Pagination metadata',
+    type: PaginationMetaDto,
+  })
+  @Type(() => PaginationMetaDto)
+  @ValidateNested()
+  meta: PaginationMetaDto;
+}

--- a/server/src/modules/menus/entities/menu-item.entity.ts
+++ b/server/src/modules/menus/entities/menu-item.entity.ts
@@ -1,0 +1,91 @@
+import {
+  IsBoolean,
+  IsDate,
+  IsInt,
+  IsOptional,
+  IsString,
+  IsUUID,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { MenuCategory, OrderItem } from '@prisma/client';
+
+export class MenuEntity {
+  @ApiProperty({
+    description: 'Menu item UUID',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
+  @IsUUID()
+  id: string;
+
+  @ApiProperty({
+    description: 'Name of the menu item',
+    example: 'Latte',
+  })
+  @IsString()
+  name: string;
+
+  @ApiPropertyOptional({
+    description: 'Description of the menu item',
+    example: 'Smooth coffee with steamed milk',
+  })
+  @IsOptional()
+  @IsString()
+  description?: string | null;
+
+  @ApiProperty({
+    description: 'Price in smallest currency unit',
+    example: 6000,
+  })
+  @IsInt()
+  price: number;
+
+  @ApiPropertyOptional({
+    description: 'Image URL for the menu item',
+    example:
+      'https://upload.wikimedia.org/wikipedia/commons/thumb/e/e7/Kawaii_paper_coffee_cup_clip_art.svg/1920px-Kawaii_paper_coffee_cup_clip_art.svg.png?20191207190614',
+  })
+  @IsOptional()
+  @IsString()
+  imageUrl?: string | null;
+
+  @ApiProperty({
+    description: 'Whether the item is active/available',
+    example: true,
+  })
+  @IsBoolean()
+  active: boolean;
+
+  @ApiPropertyOptional({
+    description: 'Category UUID',
+    example: '550e8400-e29b-41d4-a716-446655440001',
+  })
+  @IsOptional()
+  @IsUUID()
+  categoryId?: string | null;
+
+  @ApiPropertyOptional({
+    description: 'Related category object',
+  })
+  @IsOptional()
+  category?: MenuCategory | null;
+
+  @ApiPropertyOptional({
+    description: 'Related order items',
+  })
+  @IsOptional()
+  orderItems?: OrderItem[];
+
+  @ApiProperty({
+    description: 'Creation timestamp',
+    example: '2024-01-01T12:00:00.000Z',
+  })
+  @IsDate()
+  createdAt: Date;
+
+  @ApiProperty({
+    description: 'Last update timestamp',
+    example: '2024-01-02T12:00:00.000Z',
+  })
+  @IsDate()
+  updatedAt: Date;
+}

--- a/server/src/modules/menus/interfaces/menu-item.repository.interface.ts
+++ b/server/src/modules/menus/interfaces/menu-item.repository.interface.ts
@@ -1,0 +1,39 @@
+import { MenuEntity } from '../entities/menu-item.entity';
+import { GetAllMenuDto } from 'src/modules/menus/dto/request/get-all-menu.dto';
+import { GetAllMenuItemsResponse } from 'src/modules/menus/dto/response/get-all-menu-item.response';
+
+export const IMenuItemRepositoryToken: unique symbol = Symbol(
+  'IMenuItemRepository',
+);
+
+export interface IMenuItemRepository {
+  /**
+   * Find a menu item by its id.
+   */
+  findById(id: string): Promise<MenuEntity | null>;
+
+  /**
+   * Find a menu item by its unique name.
+   */
+  findByName(name: string): Promise<MenuEntity | null>;
+
+  /**
+   * Return a list of menu items that match the filter.
+   */
+  findAll(filter?: GetAllMenuDto): Promise<GetAllMenuItemsResponse>;
+
+  /**
+   * Create a new menu item. Accepts a partial entity (id/timestamps may be generated).
+   */
+  create(data: Partial<MenuEntity>): Promise<MenuEntity>;
+
+  /**
+   * Update an existing menu item by id.
+   */
+  update(id: string, data: Partial<MenuEntity>): Promise<MenuEntity>;
+
+  /**
+   * Delete a menu item by id.
+   */
+  delete(id: string): Promise<void>;
+}

--- a/server/src/modules/menus/menus.module.ts
+++ b/server/src/modules/menus/menus.module.ts
@@ -1,0 +1,25 @@
+import { Module, Provider } from '@nestjs/common';
+import { MenusController } from 'src/modules/menus/controllers/menus.controller';
+import { IMenuItemRepositoryToken } from 'src/modules/menus/interfaces/menu-item.repository.interface';
+import { MenuItemRepository } from 'src/modules/menus/repositories/menu-item.repository';
+import {
+  GetAllMenuItemsUseCase,
+  GetAllMenuItemsUseCaseToken,
+} from 'src/modules/menus/usecases/get-all-menu-items.usecase';
+
+const providers: Provider[] = [
+  {
+    provide: IMenuItemRepositoryToken,
+    useClass: MenuItemRepository,
+  },
+  {
+    provide: GetAllMenuItemsUseCaseToken,
+    useClass: GetAllMenuItemsUseCase,
+  },
+];
+
+@Module({
+  controllers: [MenusController],
+  providers: [...providers],
+})
+export class MenusModule {}

--- a/server/src/modules/menus/repositories/menu-item.repository.ts
+++ b/server/src/modules/menus/repositories/menu-item.repository.ts
@@ -1,0 +1,93 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { Injectable } from '@nestjs/common';
+import { MenuEntity } from '../entities/menu-item.entity';
+import { IMenuItemRepository } from '../interfaces/menu-item.repository.interface';
+import { PrismaService } from 'src/shared/prisma/prisma.service';
+import { Builder } from 'builder-pattern';
+
+import { PaginationMetaDto } from 'src/shared/dtos/pagination.dto';
+import { GetAllMenuDto } from 'src/modules/menus/dto/request/get-all-menu.dto';
+import { GetAllMenuItemsResponse } from 'src/modules/menus/dto/response/get-all-menu-item.response';
+import { Prisma } from '@prisma/client';
+
+@Injectable()
+export class MenuItemRepository implements IMenuItemRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  findById(id: string): Promise<MenuEntity | null> {
+    throw new Error('MenuItemRepository.findById not implemented');
+  }
+
+  findByName(name: string): Promise<MenuEntity | null> {
+    throw new Error('MenuItemRepository.findByName not implemented');
+  }
+
+  async findAll(filter?: GetAllMenuDto): Promise<GetAllMenuItemsResponse> {
+    const where: Prisma.MenuItemWhereInput = {};
+    if (filter?.active !== undefined) where.active = filter.active;
+    if (filter?.categoryId) where.categoryId = filter.categoryId;
+    if (filter?.search) {
+      const q = filter.search;
+      where.OR = [
+        { name: { contains: q, mode: 'insensitive' } },
+        { description: { contains: q, mode: 'insensitive' } },
+      ];
+    }
+
+    const page = filter?.page && filter.page > 0 ? Math.floor(filter.page) : 1;
+    const limit =
+      filter?.pageSize && filter.pageSize > 0
+        ? Math.floor(filter.pageSize)
+        : 20;
+    const skip = (page - 1) * limit;
+
+    const total = await this.prisma.menuItem.count({ where });
+
+    const items = await this.prisma.menuItem.findMany({
+      where,
+      include: { category: true, orderItems: true },
+      orderBy: { name: 'asc' },
+      skip,
+      take: limit,
+    });
+
+    const data = items.map((item) =>
+      Builder<MenuEntity>()
+        .id(item.id)
+        .name(item.name)
+        .description(item.description ?? null)
+        .price(item.price)
+        .imageUrl(item.imageUrl ?? null)
+        .active(item.active)
+        .category(item.category ?? null)
+        .orderItems(item.orderItems ?? [])
+        .createdAt(item.createdAt)
+        .updatedAt(item.updatedAt)
+        .build(),
+    );
+
+    const totalPages = limit > 0 ? Math.ceil(total / limit) : 1;
+    const meta: PaginationMetaDto = {
+      total,
+      page,
+      limit,
+      totalPages,
+      hasNextPage: page < totalPages,
+      hasPreviousPage: page > 1,
+    };
+
+    return { data, meta };
+  }
+
+  create(data: Partial<MenuEntity>): Promise<MenuEntity> {
+    throw new Error('MenuItemRepository.create not implemented');
+  }
+
+  update(id: string, data: Partial<MenuEntity>): Promise<MenuEntity> {
+    throw new Error('MenuItemRepository.update not implemented');
+  }
+
+  delete(id: string): Promise<void> {
+    throw new Error('MenuItemRepository.delete not implemented');
+  }
+}

--- a/server/src/modules/menus/usecases/get-all-menu-items.usecase.spec.ts
+++ b/server/src/modules/menus/usecases/get-all-menu-items.usecase.spec.ts
@@ -1,0 +1,74 @@
+import { faker } from '@faker-js/faker';
+import { mock } from 'jest-mock-extended';
+import { GetAllMenuItemsUseCase } from 'src/modules/menus/usecases/get-all-menu-items.usecase';
+import { IMenuItemRepository } from 'src/modules/menus/interfaces/menu-item.repository.interface';
+import { MenuEntity } from 'src/modules/menus/entities/menu-item.entity';
+import { PaginationMetaDto } from 'src/shared/dtos/pagination.dto';
+import { GetAllMenuDto } from 'src/modules/menus/dto/request/get-all-menu.dto';
+
+describe('GetAllMenuItemsUseCase (mocked repo)', () => {
+  it('should return paginated menu items when repository returns data', async () => {
+    // Arrange
+    const repoMock = mock<IMenuItemRepository>();
+    const sampleItem: MenuEntity = {
+      id: faker.string.uuid(),
+      name: faker.word.words(2),
+      description: faker.lorem.sentence(),
+      price: faker.number.int({ min: 1000, max: 10000 }),
+      imageUrl: null,
+      active: true,
+      categoryId: null,
+      category: null,
+      orderItems: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    const sampleMeta: PaginationMetaDto = {
+      total: 1,
+      page: 1,
+      limit: 20,
+      totalPages: 1,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    };
+
+    repoMock.findAll.mockResolvedValue({
+      data: [sampleItem],
+      meta: sampleMeta,
+    });
+
+    const useCase = new GetAllMenuItemsUseCase(repoMock);
+
+    const query: GetAllMenuDto = { page: 1, pageSize: 20, search: undefined };
+
+    // Act
+    const result = await useCase.execute(query);
+
+    // Assert
+    expect(repoMock.findAll).toHaveBeenCalledWith(query);
+    expect(result).toEqual({ data: [sampleItem], meta: sampleMeta });
+  });
+
+  it('should forward undefined filter when no query provided', async () => {
+    // Arrange
+    const repoMock = mock<IMenuItemRepository>();
+    const sampleMeta: PaginationMetaDto = {
+      total: 0,
+      page: 1,
+      limit: 20,
+      totalPages: 0,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    };
+    repoMock.findAll.mockResolvedValue({ data: [], meta: sampleMeta });
+
+    const useCase = new GetAllMenuItemsUseCase(repoMock);
+
+    // Act
+    const result = await useCase.execute();
+
+    // Assert
+    expect(repoMock.findAll).toHaveBeenCalledWith(undefined);
+    expect(result).toEqual({ data: [], meta: sampleMeta });
+  });
+});

--- a/server/src/modules/menus/usecases/get-all-menu-items.usecase.ts
+++ b/server/src/modules/menus/usecases/get-all-menu-items.usecase.ts
@@ -1,0 +1,27 @@
+import { Inject } from '@nestjs/common';
+import { MenuEntity } from '../entities/menu-item.entity';
+
+import { PaginationMetaDto } from 'src/shared/dtos/pagination.dto';
+import {
+  IMenuItemRepository,
+  IMenuItemRepositoryToken,
+} from 'src/modules/menus/interfaces/menu-item.repository.interface';
+import { GetAllMenuDto } from 'src/modules/menus/dto/request/get-all-menu.dto';
+
+export const GetAllMenuItemsUseCaseToken: unique symbol = Symbol(
+  'GetAllMenuItemsUseCase',
+);
+
+export class GetAllMenuItemsUseCase {
+  constructor(
+    @Inject(IMenuItemRepositoryToken)
+    private readonly menuRepository: IMenuItemRepository,
+  ) {}
+
+  execute(filter?: GetAllMenuDto): Promise<{
+    data: MenuEntity[];
+    meta: PaginationMetaDto;
+  }> {
+    return this.menuRepository.findAll(filter);
+  }
+}

--- a/server/src/shared/prisma/prisma.service.ts
+++ b/server/src/shared/prisma/prisma.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
-import { PrismaClient } from 'generated/prisma';
+import { PrismaClient } from '@prisma/client';
 
 @Injectable()
 export class PrismaService


### PR DESCRIPTION
This pull request introduces a new "menus" feature to the backend, allowing for retrieval of menu items with filtering and pagination. It also updates dependencies and makes minor improvements to the health check and Swagger UI access. The most important changes are grouped below.

**Menus Feature Implementation**

* Added the new `MenusModule` with controller, DTOs, entity, repository interface, and use case for listing menu items with filtering and pagination. This includes `MenusController`, `GetAllMenuDto`, `MenuEntity`, `IMenuItemRepository`, 
* Added Swagger documentation for the menu items endpoint, describing query parameters and response structure.

**Dependency Updates**

* Added new dependencies: `builder-pattern` (for builder pattern usage), `@faker-js/faker` (for test data generation), and `jest-mock-extended` (for improved Jest mocking). Updated both `package.json` and `pnpm-lock.yaml` 

**Health Check Endpoint Improvements**

* Made the health check endpoint public by adding the `@Public()` decorator, allowing unauthenticated access
**Minor Improvements and Fixes**

* Changed the default access code for Swagger UI to `'apiv1'` for easier access during development.
* Updated Prisma client import and configuration to use `@prisma/client` directly, simplifying the setup. 
These changes collectively add a robust menu listing API, improve developer tooling, and refine existing endpoints.